### PR TITLE
Disable autoload when check if Enterprise_PageCache_Model_Processor exsits.

### DIFF
--- a/code/Debug/Block/Config.php
+++ b/code/Debug/Block/Config.php
@@ -62,7 +62,7 @@ class Magneto_Debug_Block_Config extends Magneto_Debug_Block_Abstract
 
     public function hasFullPageCache()
     {
-        return class_exists('Enterprise_PageCache_Model_Processor');
+        return class_exists('Enterprise_PageCache_Model_Processor', false);
     }
 
     /**


### PR DESCRIPTION
Autoload may case can not find Enterprise/PageCache/Model/Processor.php exception.
