### PR TITLE
Fix for script insertion on pages with comments

### DIFF
--- a/skin/js/toolbar.js
+++ b/skin/js/toolbar.js
@@ -11,7 +11,7 @@
 				j(script).remove();
 			}
 		};
-		document.documentElement.childNodes[0].appendChild(script)
+		document.getElementsByTagName('head')[0].appendChild(script)
 	}
 })(window, document, "1.3", function($, jquery_loaded) {
 


### PR DESCRIPTION
On pages where the &lt;head&gt; element is not the first page element (such as pages following [Paul Irish's conditional html class pattern](http://paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/)) the toolbar.js script insertion will fail. This fix targets the &lt;head&gt; tag directly.
