### PR TITLE
Redirect goes to default store rather than to current store.

### DIFF
--- a/code/Debug/controllers/IndexController.php
+++ b/code/Debug/controllers/IndexController.php
@@ -20,6 +20,18 @@ class Magneto_Debug_IndexController extends Mage_Core_Controller_Front_Action
     }
 
     /**
+     * @param null $defaultUrl
+     * @return Mage_Core_Controller_Varien_Action
+     */
+    protected function _redirectReferer($defaultUrl = null)
+    {
+        if ($store = $this->getRequest()->getParam('store')) {
+            Mage::app()->setCurrentStore($store);
+        }
+        return parent::_redirectReferer($defaultUrl);
+    }
+
+    /**
      * Show source code of template
      *
      * @return string


### PR DESCRIPTION
Noticed this bug after using Toggle Translate Inline and Toggle Template Hints on a non-default store scope.
