### PR TITLE
Fix toggle module status action

### DIFF
--- a/code/Debug/controllers/IndexController.php
+++ b/code/Debug/controllers/IndexController.php
@@ -302,18 +302,14 @@ class Magneto_Debug_IndexController extends Mage_Core_Controller_Front_Action
         }
 
         $moduleCurrentStatus = $moduleConfig->is('active');
-        $moduleNewStatus = !$moduleCurrentStatus;
+        $moduleNewStatus = $moduleCurrentStatus ? 'false' : 'true';
         $moduleConfigFile = $config->getOptions()->getEtcDir() . DS . 'modules' . DS . $moduleName . '.xml';
         $configContent = file_get_contents($moduleConfigFile);
 
-        function strbool($value) {
-            return $value ? 'true' : 'false';
-        }
-
-        $contents = '<br/>Active status switched to ' . (string)$moduleNewStatus . ' for module {$moduleName} in file {$moduleConfigFile}:';
+        $contents = '<br/>Active status switched to ' . $moduleNewStatus . ' for module {$moduleName} in file {$moduleConfigFile}:';
         $contents .= '<br/><code>' . htmlspecialchars($configContent) . '</code>';
 
-        $configContent = str_replace('<active>' . (string)$moduleCurrentStatus . '</active>', '<active>' . (string)$moduleNewStatus . '</active>', $configContent);
+        $configContent = str_replace('<active>' . $moduleConfig->active . '</active>', '<active>' . $moduleNewStatus . '</active>', $configContent);
 
         if (file_put_contents($moduleConfigFile, $configContent) === FALSE) {
             echo $this->_debugPanel($title, "Failed to write configuration. (Web Server's permissions for {$moduleConfigFile}?!)");


### PR DESCRIPTION
The toggle status action just wasn't working at all.  A boolean cast to string is not "true" but "1" so it would never match real XML content.