### PR TITLE
Fix - Invalid argument supplied for foreach() in controller.phtml

### DIFF
--- a/design/template/debug/controller.phtml
+++ b/design/template/debug/controller.phtml
@@ -74,6 +74,7 @@ $session = Mage::getSingleton('core/session');
 			</tr>
 		</thead>
 		<?php foreach( $_SESSION as $namespace => $data): ?>
+        <?php if(!is_array($data)) { continue; } ?>
 		<tbody>
 			<tr><th colspan="2" style="text-align: center; font-size: 120%; font-weight: bold;"><?php echo $namespace ?></th></tr>
 			<?php $row = 0; ?>


### PR DESCRIPTION
When I turn on E_STRICT error reporting I get such warning:

`Warning: Invalid argument supplied for foreach()  in /home/kuba/strona/smyk/.modman/magneto-debug/design/template/debug/controller.phtml on line 81`

The problem was that $data variable was boolean, not an array.


