### PR TITLE
Updated modman adminhtml design paths

### DIFF
--- a/modman
+++ b/modman
@@ -8,8 +8,8 @@ design/template/sheep_debug     app/design/frontend/base/default/template/sheep_
 skin                            skin/frontend/base/default/sheep_debug/
 
 # adminhtml
-design/layout/sheep_debug.xml   app/design/adminhtml/base/default/layout/sheep_debug.xml
-design/template/sheep_debug     app/design/adminhtml/base/default/template/sheep_debug
+design/layout/sheep_debug.xml   app/design/adminhtml/default/default/layout/sheep_debug.xml
+design/template/sheep_debug     app/design/adminhtml/default/default/template/sheep_debug
 skin                            skin/adminhtml/default/default/sheep_debug/
 
 #connect/Magneto_Debug.xml      var/connect/Magneto_Debug.xml


### PR DESCRIPTION
The adminhtml theme lives in default/default for some reason instead of base/default. Deploying to base/default caused the toolbar not to show in my project