### PR TITLE
solves #66 - include alias and parent name in blockname

### DIFF
--- a/code/Debug/Helper/Data.php
+++ b/code/Debug/Helper/Data.php
@@ -473,4 +473,24 @@ class Sheep_Debug_Helper_Data extends Mage_Core_Helper_Data
     {
         return Mage::getConfig();
     }
+
+
+    /**
+     * Formats the blockname used in the observer::onBlockToHtml method
+     *
+     * @param Mage_Core_Block_Abstract $block
+     * @return string
+     */
+    public function getBlockName(Mage_Core_Block_Abstract $block)
+    {
+        $blockName = $block->getParentBlock() ?
+            "{$block->getParentBlock()->getNameInLayout()}_{$block->getNameInLayout()}" :
+            "{$block->getNameInLayout()}" ;
+
+        if ($block->getBlockAlias()) {
+            $blockName .= "_{$block->getBlockAlias()}";
+        }
+
+        return $blockName;
+    }
 }

--- a/code/Debug/Model/Observer.php
+++ b/code/Debug/Model/Observer.php
@@ -250,9 +250,18 @@ class Sheep_Debug_Model_Observer
             return;
         }
 
+        $blockName = $block->getParentBlock() ?
+            "{$block->getParentBlock()->getNameInLayout()}_{$block->getNameInLayout()}" :
+            "{$block->getNameInLayout()}" ;
+
+        if ($block->getBlockAlias()) {
+            $blockName .= "_{$block->getBlockAlias()}";
+        }
+
         $requestInfo = $this->getRequestInfo();
+
         try {
-            $blockInfo = $requestInfo->getBlock($block->getNameInLayout());
+            $blockInfo = $requestInfo->getBlock($blockName);
         } catch (Exception $e) {
             // block was not found - lets add it now
             $blockInfo = $requestInfo->addBlock($block);

--- a/code/Debug/Model/Observer.php
+++ b/code/Debug/Model/Observer.php
@@ -250,13 +250,7 @@ class Sheep_Debug_Model_Observer
             return;
         }
 
-        $blockName = $block->getParentBlock() ?
-            "{$block->getParentBlock()->getNameInLayout()}_{$block->getNameInLayout()}" :
-            "{$block->getNameInLayout()}" ;
-
-        if ($block->getBlockAlias()) {
-            $blockName .= "_{$block->getBlockAlias()}";
-        }
+        $blockName = Mage::helper('sheep_debug')->getBlockName($block);
 
         $requestInfo = $this->getRequestInfo();
 


### PR DESCRIPTION
This prevents exception thrown when 2 blocks have the same name but different alias or parent