### PR TITLE
fix redirects always going to the default store main URL

### DIFF
--- a/code/Debug/controllers/ConfigController.php
+++ b/code/Debug/controllers/ConfigController.php
@@ -47,7 +47,8 @@ class Sheep_Debug_ConfigController extends Sheep_Debug_Controller_Front_Action
         $this->getService()->setVarienProfilerStatus(1);
         $this->getService()->flushCache();
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -59,7 +60,8 @@ class Sheep_Debug_ConfigController extends Sheep_Debug_Controller_Front_Action
         $this->getService()->setVarienProfilerStatus(0);
         $this->getService()->flushCache();
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 

--- a/code/Debug/controllers/ModelController.php
+++ b/code/Debug/controllers/ModelController.php
@@ -25,7 +25,8 @@ class Sheep_Debug_ModelController extends Sheep_Debug_Controller_Front_Action
             Mage::getSingleton('core/session')->addError('Unable to enable SQL profiler: ' . $e->getMessage());
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -43,7 +44,8 @@ class Sheep_Debug_ModelController extends Sheep_Debug_Controller_Front_Action
             Mage::getSingleton('core/session')->addError('Unable to disable SQL profiler: ' . $e->getMessage());
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 

--- a/code/Debug/controllers/ModuleController.php
+++ b/code/Debug/controllers/ModuleController.php
@@ -26,7 +26,8 @@ class Sheep_Debug_ModuleController extends Sheep_Debug_Controller_Front_Action
             Mage::getSingleton('core/session')->addError('Unable to enable module: ' . $e->getMessage());
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -46,7 +47,8 @@ class Sheep_Debug_ModuleController extends Sheep_Debug_Controller_Front_Action
             Mage::getSingleton('core/session')->addError('Unable to disable module: ' . $e->getMessage());
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 }

--- a/code/Debug/controllers/UtilController.php
+++ b/code/Debug/controllers/UtilController.php
@@ -60,7 +60,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -80,7 +81,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -100,7 +102,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -119,7 +122,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -137,7 +141,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -154,7 +159,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 
@@ -172,7 +178,8 @@ class Sheep_Debug_UtilController extends Sheep_Debug_Controller_Front_Action
             $this->getSession()->addError($message);
         }
 
-        $this->_redirectReferer();
+        $this->getResponse()->setRedirect();
+        $this->getResponse()->sendResponse();
     }
 
 }


### PR DESCRIPTION
I'm running a multi store setup and have noticed, that whenever I use one of the magneto-debug utilities (like "Enable/disable template hints" etc.), I get redirected to the default store main URL, instead of the page in the store I'm currently on.

I haven't yet investigated, why `_redirectReferer` always redirects to the default store URL, but the changes in this commit fix that behaviour and make the redirects work as expected.