### PR TITLE
This fix checks if magento is installed before running sheep debug.

### DIFF
--- a/code/Debug/Helper/Data.php
+++ b/code/Debug/Helper/Data.php
@@ -27,6 +27,10 @@ class Sheep_Debug_Helper_Data extends Mage_Core_Helper_Data
      */
     public function isEnabled()
     {
+        if(!Mage::isInstalled()) {
+            return false;
+        }
+
         return (bool)Mage::getStoreConfig(self::DEBUG_OPTIONS_ENABLE_PATH);
     }
 


### PR DESCRIPTION
We install sheep-debug as part of our base install, which is all run through composer.

We're running into an issue where if you deploy a new project and try to access it before magento has been installed you get a 500 error instead of the web installer. 

This is because `replaceProfiler` fetches the core_write connection and tries to replace the profiler without checking if magento is installed. This fix adds an extra check in `isEnabled` in the Data helper to ensure core_write is available.